### PR TITLE
Make cookiecutter use the openbb-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Before using the Cookiecutter, ensure that you have Python installed on your sys
 3. Import `obb` and use your extension:
 
    ```python
-   from openbb import obb
+   from package_name import obb
 
    obb.<package_name>.<command>
    exit()
    ```
 
-   > On first launch, your extension will be automatically recognized and built by the OpenBB Platform v4. If you modify your extension, you can trigger the rebuild by using this command `python -c "import openbb; openbb.build()"`
+   > On first launch, your extension will be automatically recognized and built by the OpenBB Platform v4. If you modify your extension, you can trigger the rebuild by using this command `python -c "import package_name; package_name.build()"`
 
    If your extension requires an API key you can pass it by doing the following:
 

--- a/{{cookiecutter.project_tag}}/README.md
+++ b/{{cookiecutter.project_tag}}/README.md
@@ -18,5 +18,6 @@ We recommend you check out the files in the following order:
 
 * `{{cookiecutter.package_name}}/README.md`
 * `{{cookiecutter.package_name}}/models/example.py`
+* `{{cookiecutter.package_name}}/provider.py`
 * `{{cookiecutter.package_name}}/__init__.py`
 * `{{cookiecutter.package_name}}/router.py`

--- a/{{cookiecutter.project_tag}}/pyproject.toml
+++ b/{{cookiecutter.project_tag}}/pyproject.toml
@@ -8,8 +8,7 @@ packages = [{ include = "{{ cookiecutter.package_name }}" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"
-# TODO: Change this to the actual version of the core once published
-openbb-core = { path = "/Users/igor/Documents/GitHub/OpenBBTerminal/openbb_platform/core" }
+openbb-core = { version = "^1.1.0" }
 openbb-devtools = { version = "^1.0.0b1" }
 
 [build-system]

--- a/{{cookiecutter.project_tag}}/pyproject.toml
+++ b/{{cookiecutter.project_tag}}/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "{{ cookiecutter.project_tag }}"
-version = "0.2.0"
+version = "1.0.0"
 description = ""
 authors = ["{{ cookiecutter.full_name }} <{{ cookiecutter.email }}>"]
 readme = "README.md"
@@ -8,7 +8,8 @@ packages = [{ include = "{{ cookiecutter.package_name }}" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"
-openbb = { version = "^4.0.0b2" }
+# TODO: Change this to the actual version of the core once published
+openbb-core = { path = "/Users/igor/Documents/GitHub/OpenBBTerminal/openbb_platform/core" }
 openbb-devtools = { version = "^1.0.0b1" }
 
 [build-system]
@@ -19,4 +20,4 @@ build-backend = "poetry.core.masonry.api"
 {{ cookiecutter.package_name }} = "{{ cookiecutter.package_name }}.router:router"
 
 [tool.poetry.plugins."openbb_provider_extension"]
-{{ cookiecutter.package_name }} = "{{ cookiecutter.package_name }}:provider"
+{{ cookiecutter.package_name }} = "{{ cookiecutter.package_name }}.provider:provider"

--- a/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/__init__.py
@@ -1,20 +1,43 @@
 """{{ cookiecutter.package_name }} OpenBB Platform extension."""
+from pathlib import Path
+from typing import List, Optional, Union
 
-from openbb_core.provider.abstract.provider import Provider
-from {{cookiecutter.package_name}}.models.example import ExampleFetcher
+from openbb_core.app.static.app_factory import BaseApp as _BaseApp
+from openbb_core.app.static.app_factory import create_app as _create_app
+from openbb_core.app.static.package_builder import \
+    PackageBuilder as _PackageBuilder
 
-# mypy: disable-error-code="list-item"
+_this_dir = Path(__file__).parent.resolve()
+_PackageBuilder(_this_dir).auto_build()
 
-provider = Provider(
-    name="{{cookiecutter.package_name}}",
-    description="Data provider for {{cookiecutter.project_name}}.",
-    # Only add 'credentials' if they are needed.
-    # For multiple login details, list them all here.
-    # credentials=["api_key"],
-    website="https://{{cookiecutter.project_tag}}.com",
-    # Here, we list out the fetchers showing what our provider can get.
-    # The dictionary key is the fetcher's name, used in the `router.py`.
-    fetcher_dict={
-        "Example": ExampleFetcher,
-    }
-)
+
+def build(
+    modules: Optional[Union[str, List[str]]] = None,
+    lint: bool = True,
+    verbose: bool = False,
+) -> None:
+    """Build extension modules.
+
+    Parameters
+    ----------
+    modules : Optional[List[str]], optional
+        The modules to rebuild, by default None
+        For example: "/news" or ["/news", "/crypto"]
+        If None, all modules are rebuilt.
+    lint : bool, optional
+        Whether to lint the code, by default True
+    verbose : bool, optional
+        Enable/disable verbose mode
+    """
+    _PackageBuilder(_this_dir, lint, verbose).build(modules)
+
+
+try:
+    # pylint: disable=import-outside-toplevel
+    from {{ cookiecutter.package_name }}.package.__extensions__ import Extensions as _Extensions
+
+    obb: Union[_BaseApp, _Extensions] = _create_app(_Extensions)  # type: ignore
+    sdk = obb
+except (ImportError, ModuleNotFoundError):
+    print("Failed to import extensions.")
+    obb = sdk = _create_app()  # type: ignore

--- a/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/models/example.py
+++ b/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/models/example.py
@@ -15,7 +15,7 @@ be entirely custom, or inherit from the OpenBB standardized models.
 
 This file shows an example of how to integrate data from a provider.
 """
-
+# pylint: disable=unused-argument
 from typing import Any, Dict, List, Optional
 
 from openbb_core.provider.abstract.data import Data
@@ -110,7 +110,9 @@ class ExampleFetcher(
         return example_response
 
     @staticmethod
-    def transform_data(data: List[dict]) -> List[ExampleData]:
+    def transform_data(
+        query: ExampleQueryParams, data: List[dict], **kwargs: Any
+    ) -> List[ExampleData]:
         """Define example transform_data.
 
         Right now, we're converting the data to fit our desired format.

--- a/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/provider.py
+++ b/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/provider.py
@@ -1,0 +1,20 @@
+"""{{ cookiecutter.package_name }} OpenBB Platform Provider."""
+
+from openbb_core.provider.abstract.provider import Provider
+from {{cookiecutter.package_name}}.models.example import ExampleFetcher
+
+# mypy: disable-error-code="list-item"
+
+provider = Provider(
+    name="{{cookiecutter.package_name}}",
+    description="Data provider for {{cookiecutter.project_name}}.",
+    # Only add 'credentials' if they are needed.
+    # For multiple login details, list them all here.
+    # credentials=["api_key"],
+    website="https://{{cookiecutter.project_tag}}.com",
+    # Here, we list out the fetchers showing what our provider can get.
+    # The dictionary key is the fetcher's name, used in the `router.py`.
+    fetcher_dict={
+        "Example": ExampleFetcher,
+    }
+)

--- a/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/router.py
+++ b/{{cookiecutter.project_tag}}/{{cookiecutter.package_name}}/router.py
@@ -45,4 +45,4 @@ async def model_example(
     extra_params: ExtraParams,
 ) -> OBBject[BaseModel]:
     """Example Data."""
-    return OBBject(results=Query(**locals()).execute())
+    return await OBBject.from_query(Query(**locals()))


### PR DESCRIPTION
This makes the cookiecutter produce lean gluten-free cookies by relying on the `openbb-core` instead of `openbb`.

There were two changes that took place that have changed the way the cookiecutter was used previously and they are:

- We reverted back to doing `from package_name import obb` 
- To not end up in circular imports, the `Provider` was moved into a `provider.py` file instead of the `__init__.py`. This is the way it was done on the Platform V4 previous to us moving it into the `__init__.py` to reduce the amount of files.

In order to merge this, we need to publish the new version of the `openbb-core` as two bugs were found inside of it while making this possible. 